### PR TITLE
add animatedStyle props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ export default class App extends Component {
     }
   }
   render() {
-    const {colors, children} = this.props;
+    const {colors, children, animatedStyle} = this.props;
     const props = this.props;
     return (
       <View {...props}>
@@ -87,6 +87,7 @@ export default class App extends Component {
               style={[
                 StyleSheet.absoluteFill,
                 {backgroundColor: item, opacity},
+                animatedStyle
               ]}
             />
           );


### PR DESCRIPTION
passing borderRadius to style props have no effect while applying it directly into Animated.View does the job, so I added the possibility to pass styling to animated view directly.